### PR TITLE
update snapshot repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ options in package.json, under the `gwenWeb` key:
 - `mavenRepo`: Specifies the Maven repo to download Gwen-Web from. Useful if you
   have eg. a local Artifactory instance to cache Gwen-Web in. Defaults to Maven
   Central (https://repo1.maven.org/maven2/), or Sonatype Snapshots
-  (https://oss.sonatype.org/content/repositories/snapshots/) if a snapshot
+  (https://s01.oss.sonatype.org/content/repositories/snapshots/) if a snapshot
   version was specified.
 
 License

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -7,7 +7,7 @@ export interface Config {
 
 function getDefaultRepo(version = "") {
   if (version.includes("SNAPSHOT")) {
-    return "https://oss.sonatype.org/content/repositories/snapshots/";
+    return "https://s01.oss.sonatype.org/content/repositories/snapshots/";
   } else {
     return "https://repo1.maven.org/maven2/";
   }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -20,7 +20,7 @@ describe("getConfig", () => {
 
     expect(config.version).toBe("2.0.0-SNAPSHOT");
     expect(config.mavenRepo).toBe(
-      "https://oss.sonatype.org/content/repositories/snapshots/"
+      "https://s01.oss.sonatype.org/content/repositories/snapshots/"
     );
   });
 });


### PR DESCRIPTION
Snapshot repo host updated from oss.sonatype.org to s01.oss.sonatype.org.