### PR TITLE
Skip version fetching if exact Gwen version is specified

### DIFF
--- a/lib/version.ts
+++ b/lib/version.ts
@@ -15,6 +15,9 @@
  */
 
 import semverMaxSatisfying from "semver/ranges/max-satisfying";
+import semverMinVersion from "semver/ranges/min-version";
+import semverSatisfies from "semver/functions/satisfies";
+import semverInc from "semver/functions/inc";
 import urljoin from "url-join";
 import { DOMParser } from "@xmldom/xmldom";
 import { isNodeLike } from "@xmldom/is-dom-node";
@@ -84,25 +87,44 @@ async function getVersionInfo(config: Config): Promise<VersionInfo> {
 export default async function getDesiredVersion(
   config: Config,
 ): Promise<string> {
-  const versionInfo = await getVersionInfo(config);
   const versionRange = config.version.endsWith("-SNAPSHOT")
     ? config.version
     : (process.env.GWEN_WEB_VERSION ?? config.version);
 
-  if (versionRange === "latest") {
-    console.log("No version specified, using latest");
-    return versionInfo.latestVersion;
-  }
-  if (versionRange.endsWith("-SNAPSHOT")) {
+  if (isExactVersion(versionRange)) {
     return versionRange;
-  }
-  const resolvedVersion = semverMaxSatisfying(
-    versionInfo.versions,
-    versionRange,
-  );
-  if (resolvedVersion === null) {
-    throw new Error("Failed to resolve specified Gwen-Web version.");
-  }
+  } else {
+    const versionInfo = await getVersionInfo(config);
+    if (versionRange === "latest") {
+      console.log("No version specified, using latest");
+      return versionInfo.latestVersion;
+    }
+    if (versionRange.endsWith("-SNAPSHOT")) {
+      return versionRange;
+    }
+    const resolvedVersion = semverMaxSatisfying(
+      versionInfo.versions,
+      versionRange,
+    );
+    if (resolvedVersion === null) {
+      throw new Error("Failed to resolve specified Gwen-Web version.");
+    }
 
-  return resolvedVersion;
+    return resolvedVersion;
+  }
+}
+
+function isExactVersion(versionRange: string): boolean {
+  if (versionRange === "latest") {
+    return false;
+  } else {
+    const minVersion = semverMinVersion(versionRange);
+    if (!minVersion) return false;
+
+    // Check if the range satisfies only its minimum bound and nothing higher
+    return (
+      semverSatisfies(minVersion.version, versionRange) &&
+      !semverSatisfies(semverInc(minVersion.version, "patch")!, versionRange)
+    );
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
   "bin": {
     "gwen": "./bin/gwen.js"
   },
-  "files": ["bin", "dist"],
+  "files": [
+    "bin",
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "format": "biome format --write",

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -52,6 +52,7 @@ describe("getDesiredVersion", () => {
   });
 
   it("should return the version specified in package.json (default repo)", async () => {
+    mockFetch.mockReset();
     await expect(
       getDesiredVersion({
         ...configDefaultRepo,
@@ -61,6 +62,7 @@ describe("getDesiredVersion", () => {
   });
 
   it("should return the version specified in package.json (custom repo)", async () => {
+    mockFetch.mockReset();
     await expect(
       getDesiredVersion({
         ...configCustomRepo,
@@ -70,6 +72,7 @@ describe("getDesiredVersion", () => {
   });
 
   it("should return the SNAPSHOT version specified in package.json (default repo)", async () => {
+    mockFetch.mockReset();
     await expect(
       getDesiredVersion({
         ...configDefaultRepo,
@@ -79,6 +82,7 @@ describe("getDesiredVersion", () => {
   });
 
   it("should return the SNAPSHOT version specified in package.json (custom repo)", async () => {
+    mockFetch.mockReset();
     await expect(
       getDesiredVersion({
         ...configCustomRepo,
@@ -107,7 +111,7 @@ describe("getDesiredVersion", () => {
 
   it("should return the version specified in environment variables (default repo)", async () => {
     process.env.GWEN_WEB_VERSION = "2.10.0";
-
+    mockFetch.mockReset();
     await expect(
       getDesiredVersion({
         ...configDefaultRepo,
@@ -118,7 +122,7 @@ describe("getDesiredVersion", () => {
 
   it("should return the version specified in environment variables  (custom repo)", async () => {
     process.env.GWEN_WEB_VERSION = "4.2.7";
-
+    mockFetch.mockReset();
     await expect(
       getDesiredVersion({
         ...configCustomRepo,
@@ -129,7 +133,7 @@ describe("getDesiredVersion", () => {
 
   it("should ignore the version specified in environment variables when using a SNAPSHOT (default repo)", async () => {
     process.env.GWEN_WEB_VERSION = "2.10.0";
-
+    mockFetch.mockReset();
     await expect(
       getDesiredVersion({
         ...configDefaultRepo,
@@ -140,7 +144,7 @@ describe("getDesiredVersion", () => {
 
   it("should ignore the version specified in environment variables when using a SNAPSHOT (custom repo)", async () => {
     process.env.GWEN_WEB_VERSION = "4.2.7";
-
+    mockFetch.mockReset();
     await expect(
       getDesiredVersion({
         ...configCustomRepo,


### PR DESCRIPTION
Skip fetching Gwen versions from repo If exact GwenWeb version is specified. This is to avoid making calls to the repo to resolve the version when an explicit one is provided. In this case the exact given version can be used without needing to be resolved.